### PR TITLE
fix(cache): Issues with Discord client cache

### DIFF
--- a/src/main/java/dev/tonimatas/listeners/NewsThreadsListener.java
+++ b/src/main/java/dev/tonimatas/listeners/NewsThreadsListener.java
@@ -5,6 +5,7 @@ import dev.tonimatas.util.Messages;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
@@ -15,10 +16,10 @@ public class NewsThreadsListener extends ListenerAdapter {
         if (event.getChannel().getId().equals(BotFiles.CONFIG.getNewsChannelId())) {
             JDA jda = event.getJDA();
             
-            event.getMessage().createThreadChannel("Comments").queue(thread -> {
-                MessageEmbed embed = Messages.getDefaultEmbed(jda, "News Comments", "Here we can discuss things about the news.");
-                thread.sendMessageEmbeds(embed).queue();
-            });
+            ThreadChannel thread = event.getMessage().createThreadChannel("Comments").complete();
+
+            MessageEmbed embed = Messages.getDefaultEmbed(jda, "News Comments", "Here we can discuss things about the news.");
+            thread.sendMessageEmbeds(embed).complete();
             
             addReactions(event.getMessage());
         } else if (event.getChannel().getId().equals(BotFiles.CONFIG.getAnnouncementsChannelId())) {


### PR DESCRIPTION
When I send an announcement and the bots add the reactions, the first disappear